### PR TITLE
Restrict endpoint to WP user with edit_posts

### DIFF
--- a/admin-notice.php
+++ b/admin-notice.php
@@ -88,7 +88,7 @@ function gnotice_rest_init() {
 		array(
 			'methods'             => \WP_REST_Server::READABLE,
 			'callback'            => 'get_email_notification',
-			'permission_callback' => '__return_true',
+			'permission_callback' => function() { return current_user_can('edit_posts'); },
 		)
 	);
 }


### PR DESCRIPTION
Restrict endpoint to logged in WP user with edit_posts

After PR #1 is merged, we can lock down the REST API endpoint because `wp.apiFetch()` authenticates the WordPress use automatically.